### PR TITLE
remove back arrow when on main window

### DIFF
--- a/src/im/tox/antox/MainActivity.java
+++ b/src/im/tox/antox/MainActivity.java
@@ -98,7 +98,7 @@ public class MainActivity extends Activity {
 				});
 
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-			getActionBar().setDisplayHomeAsUpEnabled(true);
+			getActionBar().setDisplayHomeAsUpEnabled(false);
 		}
 	}
 


### PR DESCRIPTION
There is nothing to back to, so we shouldn't have a back arrow, right?
