### PR TITLE
App Crash Fix onStop()

### DIFF
--- a/app/src/main/java/im/tox/antox/MainActivity.java
+++ b/app/src/main/java/im/tox/antox/MainActivity.java
@@ -282,7 +282,9 @@ public class MainActivity extends ActionBarActivity {
 
     @Override
     public void onStop() {
-        scheduleTaskExecutor.shutdownNow();
+        if(scheduleTaskExecutor != null){
+            scheduleTaskExecutor.shutdownNow();
+        }
         super.onStop();
     }
 


### PR DESCRIPTION
App crashes whenever scheduleTaskExecutor is null. Need to call
scheduleTaskExecutor.shutdownNow() only if it not null.
