### PR TITLE
Fix lint error about the use of non Default Fragment Constructor

### DIFF
--- a/app/src/main/java/im/tox/antox/ContactsFragment.java
+++ b/app/src/main/java/im/tox/antox/ContactsFragment.java
@@ -1,8 +1,8 @@
 package im.tox.antox;
 
-import android.support.v4.app.FragmentTransaction;
-import android.support.v4.app.Fragment;
 import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentTransaction;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -28,7 +28,11 @@ public class ContactsFragment extends Fragment {
     }
 
     public void onChangeFriendRequest(int position, String key, String message) {
-        Fragment newFragment = new FriendRequestFragment(key, message);
+        Fragment newFragment = new FriendRequestFragment();
+        Bundle bundle = new Bundle();
+        bundle.putString(key, key);
+        bundle.putString(message, message);
+        newFragment.setArguments(bundle);
         FragmentTransaction transaction = getFragmentManager().beginTransaction();
         transaction.replace(R.id.right_pane, newFragment);
         transaction.addToBackStack(null);

--- a/app/src/main/java/im/tox/antox/DHTDialogFragment.java
+++ b/app/src/main/java/im/tox/antox/DHTDialogFragment.java
@@ -35,10 +35,8 @@ public class DHTDialogFragment extends DialogFragment{
 
     EditText dhtIP, dhtPort, dhtKey;
 
-    public DHTDialogFragment(String ip_, String port_, String key_) {
-        ip = ip_;
-        port = port_;
-        key = key_;
+    public DHTDialogFragment() {
+
     }
     // Override the Fragment.onAttach() method to instantiate the DHTDialogListener
     @Override

--- a/app/src/main/java/im/tox/antox/FriendRequestFragment.java
+++ b/app/src/main/java/im/tox/antox/FriendRequestFragment.java
@@ -20,9 +20,8 @@ public class FriendRequestFragment extends Fragment {
     private String key;
     private String message;
 
-    public FriendRequestFragment(String key, String message) {
-        this.key = key;
-        this.message = message;
+    public FriendRequestFragment() {
+
     }
 
     @Override

--- a/app/src/main/java/im/tox/antox/SettingsActivity.java
+++ b/app/src/main/java/im/tox/antox/SettingsActivity.java
@@ -171,7 +171,13 @@ public class SettingsActivity extends ActionBarActivity
         boolean checked = ((CheckBox) view).isChecked();
         if(checked) {
             // Create an instance of the dialog fragment and show it
-            DialogFragment dialog = new DHTDialogFragment(dhtIP, dhtPort, dhtKey);
+            DialogFragment dialog = new DHTDialogFragment();
+            Bundle bundle = new Bundle();
+            bundle.putString(dhtIP, dhtIP);
+            bundle.putString(dhtPort, dhtPort);
+            bundle.putString(dhtKey, dhtKey);
+            dialog.setArguments(bundle);
+
             dialog.show(getSupportFragmentManager(), "NoticeDialogFragment");
         }
     }


### PR DESCRIPTION
This fixes some lint Errors about the use of non Default Fragment Constructors.

The fix is to use a Bundle and set it as argument.
