### PR TITLE
Fix lint complaining about use of higher api then minSdkVersion

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion '19.0.2'
 
     defaultConfig {
-        minSdkVersion 8
+        minSdkVersion 14
         targetSdkVersion 19
     }
 


### PR DESCRIPTION
This raises the SDK Version from 8 to 14 as higher API level functions where in use.
