### PR TITLE
Fixed crash in SettingsActivity

### DIFF
--- a/app/src/main/java/im/tox/antox/SettingsActivity.java
+++ b/app/src/main/java/im/tox/antox/SettingsActivity.java
@@ -146,10 +146,14 @@ public class SettingsActivity extends ActionBarActivity
         editor.commit();
 
         /* Send an intent to ToxService notifying change of settings */
+        /* IF we send an intent the updatedSettings will always be null*/
+        /*
         Intent updateSettings = new Intent(this, ToxService.class);
         updateSettings.setAction(Constants.UPDATE_SETTINGS);
         updateSettings.putExtra("newSettings", updatedSettings);
         this.startService(updateSettings);
+        */
+
 
         Context context = getApplicationContext();
         CharSequence text = "Settings updated";


### PR DESCRIPTION
The updatedsettings array defined above is null so the app crashes when it starts Toxservice service and the method called is for ProfileActivity  not for SettingsActivity.  
