### PR TITLE
Fixed the layout cutting out timestamp and unread count.

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,10 +8,11 @@
     <!-- Left side pane. (Master) -->
     <fragment android:id="@+id/fragment_contacts"
         android:name="im.tox.antox.ContactsFragment"
-        android:layout_width="320dp"
+        android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:layout_marginRight="30dp"
         android:layout_gravity="left"
-        tools:layout="@layout/fragment_contacts" />
+        tools:layout="@layout/fragment_leftpane" />
 
     <!-- Right side page. (Slave)
     <fragment android:id="@+id/fragment_chat"


### PR DESCRIPTION
Somehow, on my S2 the timestamp and unread message count were "outside" the left pane, and not visible.
## Before

![device-2014-03-15-133323](https://f.cloud.github.com/assets/1079024/2428287/36a49f7e-ac3e-11e3-92db-4737078176d7.png)
## After

![device-2014-03-15-133232](https://f.cloud.github.com/assets/1079024/2428288/3e0e413e-ac3e-11e3-9458-c4ea88e95392.png)
