### PR TITLE
Add a space on the actions on dialog between the word "on" and the user's name

### DIFF
--- a/app/src/main/java/im/tox/antox/ContactsFragment.java
+++ b/app/src/main/java/im/tox/antox/ContactsFragment.java
@@ -126,7 +126,7 @@ public class ContactsFragment extends Fragment {
                             getResources().getString(R.string.friend_action_block)
                     };
                 }
-                builder.setTitle(main_act.getString(R.string.contacts_actions_on) + item.first)
+                builder.setTitle(main_act.getString(R.string.contacts_actions_on) + " " + item.first)
                         .setCancelable(true)
                         .setItems(items, new DialogInterface.OnClickListener() {
                             public void onClick(DialogInterface dialog, int index) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,7 +93,7 @@
     <string name="friend_action_block">Block</string>
     <string name="group_action_leave">Leave Group</string>
 
-    <string name="contacts_actions_on">Actions on </string>
+    <string name="contacts_actions_on">Actions on</string>
     <string name="contacts_clear_saved_logs">Do you want to clear the saved chat logs as well?</string>
 
     <!--  Misc -->


### PR DESCRIPTION
On the contactsFragment, add a space between the word "on" and the username in the AlertDialog text
