### PR TITLE
Handle NumberFormatException in parsing the friendKey.

### DIFF
--- a/app/src/main/java/im/tox/antox/AddFriendActivity.java
+++ b/app/src/main/java/im/tox/antox/AddFriendActivity.java
@@ -124,8 +124,13 @@ public class AddFriendActivity extends ActionBarActivity {
             return false;
         }
         int x = 0;
-        for (int i = 0; i < friendKey.length(); i += 4) {
-            x = x ^ Integer.valueOf(friendKey.substring(i, i + 4), 16);
+        try {
+            for (int i = 0; i < friendKey.length(); i += 4) {
+                x = x ^ Integer.valueOf(friendKey.substring(i, i + 4), 16);
+            }
+        }
+        catch (NumberFormatException e) {
+            return false;
         }
         if (x != 0)
             return false;


### PR DESCRIPTION
In some cases, when adding a ToxID, the app rises a NumberFormatException. (see the log below)

http://pastebin.com/WKYJMv4R

Just added a try and catch block to fix this.
