### PR TITLE
Timestamp of the messages corresponds with the localtime of the device.

### DIFF
--- a/app/src/main/java/im/tox/antox/ChatMessagesAdapter.java
+++ b/app/src/main/java/im/tox/antox/ChatMessagesAdapter.java
@@ -3,6 +3,7 @@ package im.tox.antox;
 import android.app.Activity;
 import android.content.Context;
 import android.graphics.Color;
+import android.util.Log;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -11,6 +12,13 @@ import android.widget.ArrayAdapter;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.SimpleTimeZone;
+import java.util.TimeZone;
 
 public class ChatMessagesAdapter extends ArrayAdapter<ChatMessages> {
     Context context;
@@ -26,6 +34,24 @@ public class ChatMessagesAdapter extends ArrayAdapter<ChatMessages> {
     }
 
     private String prettifyTimestamp(String t) {
+        //Make a copy of t in case of an error.
+        String tCopy = t;
+
+        try {
+            //Set the date format.
+            DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
+            //Get the Date in UTC format.
+            dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = dateFormat.parse(t);
+
+            //Adapt the date to the local timestamp.
+            dateFormat.setTimeZone(TimeZone.getDefault());
+            t = dateFormat.format(date).toString();
+        }
+        catch (Exception e) {
+            t = tCopy;
+        }
+
         String output = "";
         String month = "";
         switch (Integer.parseInt(t.substring(5, 7))) {

--- a/app/src/main/java/im/tox/antox/LeftPaneAdapter.java
+++ b/app/src/main/java/im/tox/antox/LeftPaneAdapter.java
@@ -16,7 +16,11 @@ import android.widget.TextView;
 import im.tox.antox.Constants;
 
 import java.sql.Timestamp;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
+import java.util.TimeZone;
 
 /**
  * Created by ollie on 04/03/14.
@@ -126,16 +130,33 @@ public class LeftPaneAdapter extends BaseAdapter {
     }
 
     private String prettyTimestamp(Timestamp t) {
+        String tString = t.toString();
+
+        try {
+            //Set the date format.
+            DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
+            //Get the Date in UTC format.
+            dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date date = dateFormat.parse(tString);
+
+            //Adapt the date to the local timestamp.
+            dateFormat.setTimeZone(TimeZone.getDefault());
+            tString = dateFormat.format(date).toString();
+        }
+        catch (Exception e) {
+            tString = t.toString();
+        }
+
         java.util.Date date= new java.util.Date();
         Timestamp current = new Timestamp(date.getTime());
         String output;
         String month = "";
-        if (current.toString().substring(0,10).equals(t.toString().substring(0,10))){
-            output = t.toString().substring(11,16);
-        } else if (t.toString().substring(0,10).equals("1899-12-31")) {
+        if (current.toString().substring(0,10).equals(tString.substring(0,10))){
+            output = tString.substring(11,16);
+        } else if (tString.substring(0,10).equals("1899-12-31")) {
             output = "";
         } else {
-            switch (Integer.parseInt(t.toString().substring(5,7))) {
+            switch (Integer.parseInt(tString.substring(5,7))) {
                 case 1:
                     month = "Jan";
                     break;
@@ -173,7 +194,7 @@ public class LeftPaneAdapter extends BaseAdapter {
                     month = "Dec";
                     break;
             }
-            output = month + " " + t.toString().substring(8,10);
+            output = month + " " + tString.substring(8,10);
         }
         return output;
     }


### PR DESCRIPTION
Fixed Issue #174 .

As @ollieh suggested the message timestamp should be stored in UTC format and coverted into a local timestamp when the message is shown. And that is what I implemented.
