### PR TITLE
Fix bug showing wrong time for first messages sent.

### DIFF
--- a/app/src/main/java/im/tox/antox/AntoxDB.java
+++ b/app/src/main/java/im/tox/antox/AntoxDB.java
@@ -9,6 +9,7 @@ import android.util.Log;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Random;
 
 import im.tox.jtoxcore.ToxUserStatus;
 import im.tox.antox.ToxSingleton;
@@ -143,7 +144,14 @@ public class AntoxDB extends SQLiteOpenHelper {
     public void updateUnsentMessage(int m_id) {
         Log.d("UPDATE UNSENT MESSAGE - ID : ", "" + m_id);
         SQLiteDatabase db = this.getWritableDatabase();
-        db.execSQL("UPDATE " + Constants.TABLE_CHAT_LOGS + " SET " + Constants.COLUMN_NAME_SUCCESSFULLY_SENT + "=1, " + Constants.COLUMN_NAME_TIMESTAMP + "=datetime('now', 'localtime') WHERE " + Constants.COLUMN_NAME_MESSAGE_ID + "=" + m_id + " AND " + Constants.COLUMN_NAME_IS_OUTGOING + "=1");
+        Random generator = new Random();
+        db.execSQL("UPDATE " + Constants.TABLE_CHAT_LOGS + " SET "
+                + Constants.COLUMN_NAME_SUCCESSFULLY_SENT + "=1, "
+                + Constants.COLUMN_NAME_MESSAGE_ID + "=" + generator.nextInt() + ", "
+                + Constants.COLUMN_NAME_TIMESTAMP + "=datetime('now') WHERE "
+                + Constants.COLUMN_NAME_MESSAGE_ID + "=" + m_id + " AND "
+                + Constants.COLUMN_NAME_IS_OUTGOING + "=1" + " AND "
+                + Constants.COLUMN_NAME_SUCCESSFULLY_SENT + "=0");
 
     }
 

--- a/app/src/main/java/im/tox/antox/ToxService.java
+++ b/app/src/main/java/im/tox/antox/ToxService.java
@@ -26,7 +26,6 @@ public class ToxService extends IntentService {
     private static final String TAG = "im.tox.antox.ToxService";
     private ToxSingleton toxSingleton;
 
-
     public ToxService() {
         super("ToxService");
     }
@@ -214,7 +213,8 @@ public class ToxService extends IntentService {
             String message = intent.getStringExtra("message");
             /* Send message */
             ToxFriend friend = null;
-            int id = -1;
+            Random generator = new Random();
+            int id = generator.nextInt();
             boolean sendingSucceeded = true;
             try {
                 friend = toxSingleton.friendsList.getById(key);
@@ -224,8 +224,6 @@ public class ToxService extends IntentService {
             try {
                 if (friend != null) {
                     Log.d(TAG, "Sending message to " + friend.getName());
-                    Random generator = new Random();
-                    id = generator.nextInt();
                     toxSingleton.jTox.sendMessage(friend, message, id);
                 }
             } catch (ToxException e) {
@@ -243,7 +241,7 @@ public class ToxService extends IntentService {
                 LocalBroadcastManager.getInstance(this).sendBroadcast(notify);
             } else {
                 /* Add message to chatlog */
-                toxSingleton.mDbHelper.addMessage(-1, key, message, true, false, false, false);
+                toxSingleton.mDbHelper.addMessage(id, key, message, true, false, false, false);
             /* Broadcast to update UI */
                 Intent notify = new Intent(Constants.BROADCAST_ACTION);
                 notify.putExtra("action", Constants.UPDATE_MESSAGES);


### PR DESCRIPTION
Fix Issue #194 .

The problem was with the time of the unsent messages.
Until the connection between the 2 users is made the first messages are stored as unsent. After that, they are pulled out of the database in local time and formatted again -> wrong time.

The solution was to pull them out as UTC time. But there was another problem. All messages that were once in the unsent they had the id = -1 and the update of an unsent message was based on the id.

So I gave every message a different id (this is the purpose of the id I believe, to be different for every item) and I modify the query for the database to search after the "successfully sent" column in addition to id.
