### PR TITLE
Made the keyboard do not show after users reopens the app.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,6 +40,7 @@
         <activity
             android:name="im.tox.antox.activities.MainActivity"
             android:configChanges="orientation|screenSize"
+            android:windowSoftInputMode="stateAlwaysHidden"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
Fixed Issue #220.

The problem was that the message box (edittext) had the focus and the keyboard showed up.
Now the keyboard only shows on click.
