### PR TITLE
fixed MenuItem crash below API 11

### DIFF
--- a/app/src/main/java/im/tox/antox/activities/MainActivity.java
+++ b/app/src/main/java/im/tox/antox/activities/MainActivity.java
@@ -685,9 +685,10 @@ public class MainActivity extends ActionBarActivity {
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
             setTitle(activeTitle);
             MenuItem af = menu.findItem(R.id.add_friend);
-            af.setShowAsAction(MenuItem.SHOW_AS_ACTION_NEVER);
+            MenuItemCompat.setShowAsAction(af,MenuItem.SHOW_AS_ACTION_NEVER);
             MenuItem ag= menu.add(666, 100, 100, R.string.add_to_group);
-            ag.setIcon(R.drawable.ic_action_add_group).setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
+            ag.setIcon(R.drawable.ic_action_add_group);
+            MenuItemCompat.setShowAsAction(ag,MenuItem.SHOW_AS_ACTION_ALWAYS);
             ag.setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
                 @Override
                 public boolean onMenuItemClick(MenuItem item) {
@@ -709,7 +710,8 @@ public class MainActivity extends ActionBarActivity {
             getSupportActionBar().setDisplayHomeAsUpEnabled(false);
             setTitle(R.string.app_name);
             MenuItem af = menu.findItem(R.id.add_friend);
-            af.setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM);
+            MenuItemCompat.setShowAsAction(af,MenuItem.SHOW_AS_ACTION_IF_ROOM);
+//            af.setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM);
             /*af.setIcon(R.drawable.ic_action_add_person);
             af.setTitle(R.string.add_friend);*/
             menu.removeGroup(666);


### PR DESCRIPTION
When the app was run on GingerBread it crashed because of use of "setShowsAsAction" method on MenuItems. It is because the method works on API>11. I used MenuItemCompat and fixed the error.
