### PR TITLE
Add .nomedia file creation in /Antox/

### DIFF
--- a/app/src/main/java/im/tox/antox/activities/FriendProfileActivity.java
+++ b/app/src/main/java/im/tox/antox/activities/FriendProfileActivity.java
@@ -70,6 +70,14 @@ public class FriendProfileActivity extends ActionBarActivity {
         if(!file.exists()){
             file.mkdirs();
         }
+        File noMedia = new File(Environment.getExternalStorageDirectory().getPath()+"/Antox/",".nomedia");
+        if(!noMedia.exists()){
+            try {
+                noMedia.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
         file = new File(Environment.getExternalStorageDirectory().getPath()+"/Antox/"+friendName+".png");
         generateQR(friendKey);
         Bitmap bmp = BitmapFactory.decodeFile(file.getAbsolutePath());

--- a/app/src/main/java/im/tox/antox/activities/ProfileActivity.java
+++ b/app/src/main/java/im/tox/antox/activities/ProfileActivity.java
@@ -97,6 +97,15 @@ public class ProfileActivity extends ActionBarActivity {
         if(!file.exists()){
             file.mkdirs();
         }
+
+        File noMedia = new File(Environment.getExternalStorageDirectory().getPath()+"/Antox/",".nomedia");
+        if(!noMedia.exists()){
+            try {
+                noMedia.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
         file = new File(Environment.getExternalStorageDirectory().getPath()+"/Antox/userkey_qr.png");
         generateQR(pref.getString("user_key", ""));
         Bitmap bmp = BitmapFactory.decodeFile(file.getAbsolutePath());


### PR DESCRIPTION
QR codes are currently viewable from the Gallery, a bad UX. Hide all the images from media scanning by placing a .nomedia in the main directory.
