### PR TITLE
Keep naming consistent

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,7 +92,7 @@
     <!-- Friend Profile Activity -->
     <string name="friend_profile_name">Name</string>
     <string name="friend_profile_alias">Alias</string>
-    <string name="friend_profile_key">Tox Key</string>
+    <string name="friend_profile_key">Tox ID</string>
     <string name="friend_profile_note">Status</string>
     <string name="friend_profile_button">Update Alias</string>
     <string name="friend_profile_updated">Alias has been updated</string>


### PR DESCRIPTION
Naming should be consistent. Since there is 'Tox ID' elsewhere used already..
