### PR TITLE
Update strings

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,7 +41,7 @@
     <string name="about_facebook_url">https://www.facebook.com/toxproject</string>
     <string name="about_twitter_url">https://twitter.com/ProjectTox</string>
     <string name="about_irc">We\'re on Freenode on #tox-dev</string>
-    <string name="about_version">version</string>
+    <string name="about_version">Version</string>
 
     <!--  Chat Activity -->
     <string name="chat_enter_message">Send a message</string>
@@ -53,17 +53,17 @@
     <string name="settings_custom_dht">Custom DHT node Settings</string>
     <string name="settings_use_custom_dht">Use Custom DHT node settings</string>
     <string name="settings_user_key_title">Your Tox ID</string>
-    <string name="settings_name_hint">enter your name</string>
-    <string name="settings_note_hint">enter your personal note</string>
+    <string name="settings_name_hint">Username</string>
+    <string name="settings_note_hint">Mood message</string>
     <string name="settings_dht_ip">IP address of a bootstrap (ex: 192.254.75.98)</string>
     <string name="settings_dht_port">Port address of a bootstrap (ex: 33445)</string>
     <string name="settings_dht_key">Public Key address of a bootstrap (ex: FE3914F4616E227F29B2103450D6B55A836AD4BD23F97144E2C4ABE8D504FE1B)</string>
     <string name="settings_button">Update</string>
     <string name="settings_updated">Your Settings has been updated</string>
     <string name="settings_dht_spinner_title">Advanced Settings</string>
-    <string name="settings_status_title">Set your status</string>
-    <string name="settings_note_title">Set your personal note</string>
-    <string name="settings_username_title">Set your username</string>
+    <string name="settings_status_title">Status</string>
+    <string name="settings_note_title">Mood message</string>
+    <string name="settings_username_title">Username</string>
     <string name="settings_empty_strings">You must fill out all fields</string>
     <string name="settings_invalid_key">Invalid key given</string>
     <string name="developer_string">Developed by astonex &amp; co.</string>


### PR DESCRIPTION
Telling a user this is where to set their information means that the developers couldn't properly design an app to be intuitive. Simply stating this is where the info goes should be suffice, even for novices
