### PR TITLE
Spanish translation: remove "languages" array

### DIFF
--- a/app/src/main/res/values-es/arrays.xml
+++ b/app/src/main/res/values-es/arrays.xml
@@ -6,17 +6,4 @@
         <item>Desconectados</item>
         <item>Bloqueados</item>
     </string-array>
-
-    <string-array name="languages">
-        <item>English</item>
-        <item>Deutsch</item>
-        <item>Español</item>
-        <item>Français</item>
-        <item>Italiano</item>
-        <item>Nederlands</item>
-        <item>Polski</item>
-        <item>Türkçe</item>
-        <item>Русский</item>
-        <item>Український</item>
-    </string-array>
 </resources>


### PR DESCRIPTION
There is no need to translate "languages" array, since it's a duplicate of the original one
