### PR TITLE
Set Tox ID to one line in profile

### DIFF
--- a/app/src/main/res/layout/activity_friend_profile.xml
+++ b/app/src/main/res/layout/activity_friend_profile.xml
@@ -52,23 +52,22 @@
         android:textStyle="bold" />
 
     <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:id="@+id/friendKeyText" />
+        android:id="@+id/friendKeyText"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:ellipsize="end"
+        android:paddingBottom="5dp"
+        android:singleLine="true"
+        android:layout_marginLeft="10dp"
+        android:textIsSelectable="true"
+        android:textSize="12sp" />
 
     <ImageButton
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:id="@+id/qr_code"
         android:layout_gravity="center_horizontal" />
-    <Button
-        android:layout_width="198dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="5dp"
-        android:text="@string/friend_profile_copy"
-        android:id="@+id/copyId"
-        android:layout_gravity="center_horizontal"
-        android:onClick="copyID" />
+
 
 </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/activity_profile.xml
+++ b/app/src/main/res/layout/activity_profile.xml
@@ -24,7 +24,10 @@
         <TextView
             android:id="@+id/settings_user_key"
             android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="fill_parent"
+            android:ellipsize="end"
+            android:paddingBottom="5dp"
+            android:singleLine="true"
             android:layout_marginLeft="10dp"
             android:textIsSelectable="true"
             android:textSize="12sp" />


### PR DESCRIPTION
Looks like this:
![device-2014-04-09-180645](https://cloud.githubusercontent.com/assets/2215601/2662367/036ae8ea-c03c-11e3-9cf0-3cd5c434299f.png)
Selecting and copying the Tox ID will copy the entirety, not just until the ellipsis. 
