### PR TITLE
Fixed full_logo scaling problem in About activity.

### DIFF
--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -16,12 +16,16 @@
                   android:weightSum="100"
                   tools:context=".WelcomeActivity">
 
+        <ImageView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:src="@drawable/full_logo" />
+
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="20dp"
             android:layout_weight="90"
-            android:drawableTop="@drawable/full_logo"
             android:gravity="center"
             android:text="@string/developer_string"
             android:textSize="12sp"/>


### PR DESCRIPTION
The logo on the About screen was cropped on smaller screens. This should fix it.

<img src="https://cloud.githubusercontent.com/assets/3090888/2875916/c8452e36-d429-11e3-942a-874602e6d294.png" width="50%" /><img src="https://cloud.githubusercontent.com/assets/3090888/2875917/c8513f5a-d429-11e3-8064-7d63a3dbd244.png" width="50%">
