### PR TITLE
Fix user status from covering actionbar

### DIFF
--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -29,11 +29,14 @@
             android:textColor="@color/grey_light"
             android:textSize="13sp"
             android:text="STATUS"
+            android:ellipsize="end"
+            android:singleLine="true"
             android:layout_gravity="bottom"
             android:layout_alignParentBottom="true"
             android:layout_alignLeft="@+id/chatActiveName"
             android:layout_alignStart="@+id/chatActiveName"
-            android:layout_marginBottom="5dp" />
+            android:layout_marginBottom="5dp"
+            android:layout_toLeftOf="@+id/callFriend" />
 
         <ImageButton
             android:id="@+id/callFriend"


### PR DESCRIPTION
Old layout allowed status to cover whole actionbar.
![changes](https://cloud.githubusercontent.com/assets/2215601/3362084/f5e3b184-fb05-11e3-874a-47e14e69ddb6.png)
